### PR TITLE
Fixed CMake file to reduce warnings

### DIFF
--- a/cmake/AddHDLVerilator.cmake
+++ b/cmake/AddHDLVerilator.cmake
@@ -262,7 +262,7 @@ function(add_hdl_verilator)
                 ${verilator_flags}
                 ${verilator_main}
             COMMAND
-                make
+                $(MAKE)
             ARGS
                 -f ${ARG_TARGET}.mk
             COMMAND
@@ -317,7 +317,7 @@ function(add_hdl_verilator)
                 ${verilator_flags}
                 "${verilator_main}"
             COMMAND
-                make
+                $(MAKE)
             ARGS
                 -f ${ARG_TARGET}.mk
             DEPENDS

--- a/cmake/AddHDLVerilator.cmake
+++ b/cmake/AddHDLVerilator.cmake
@@ -323,7 +323,7 @@ function(add_hdl_verilator)
             DEPENDS
                 ${verilator_sources}
                 ${verilator_includes}
-                ${verilaotr_configuration_file}
+                ${verilator_configuration_file}
             WORKING_DIRECTORY
                 ${verilator_library_dir}
             COMMENT


### PR DESCRIPTION
This is to remove the `warning: jobserver unavailable: using -j1. Add '+ to parent make rule.` message when compiling with `make -jN`.

Solution taken from: https://stackoverflow.com/questions/33171335/jobserver-unavailable-when-building-external-projects-with-cmake